### PR TITLE
move up declaration of Output

### DIFF
--- a/Source/ParticleOps.H
+++ b/Source/ParticleOps.H
@@ -156,6 +156,5 @@ struct Get
     P* m_pstruct;
 };
 
-
 } // namespace spades::particles
 #endif


### PR DESCRIPTION
## Summary
Move up declaration of Output so other functions can use it.
