### PR TITLE
Fix multiple entities per LP LVT

### DIFF
--- a/Source/SPADES.cpp
+++ b/Source/SPADES.cpp
@@ -723,14 +723,26 @@ void SPADES::rollback()
                                         : ent_parrs.m_rdata
                                               [particles::EntityRealData::
                                                    timestamp][pe_soa];
+
+                                amrex::Real max_ent_lvt = constants::LOW_NUM;
+                                for (int ne = 0;
+                                     ne <
+                                     ent_cnt_arr(
+                                         iv, particles::EntityTypes::ENTITY);
+                                     ne++) {
+                                    const auto pe = ent_getter(
+                                        ne, particles::EntityTypes::ENTITY);
+                                    const auto ent_lvt =
+                                        ent_parrs
+                                            .m_rdata[particles::EntityRealData::
+                                                         timestamp][pe];
+                                    if (ent_lvt > max_ent_lvt) {
+                                        max_ent_lvt = ent_lvt;
+                                    }
+                                }
                                 sarr(iv, constants::LVT_IDX) =
-                                    sarr(iv, constants::LVT_IDX) >
-                                            ent_parrs.m_rdata
-                                                [particles::EntityRealData::
-                                                     timestamp][pe_soa]
-                                        ? ent_parrs.m_rdata
-                                              [particles::EntityRealData::
-                                                   timestamp][pe_soa]
+                                    sarr(iv, constants::LVT_IDX) > max_ent_lvt
+                                        ? max_ent_lvt
                                         : sarr(iv, constants::LVT_IDX);
                             }
                         }

--- a/Tests/test_files/phold-multi-entity-encoded/phold-multi-entity-encoded.inp
+++ b/Tests/test_files/phold-multi-entity-encoded/phold-multi-entity-encoded.inp
@@ -6,7 +6,7 @@ geometry.prob_hi     =   1.0  1.0  1.0
 geometry.is_periodic = 1 1 1
 
 # timestepping
-amr.n_cell  = 2 2 2
+amr.n_cell  = 4 4 4
 amr.max_level = 0
 amr.max_grid_size = 8
 amr.blocking_factor = 2
@@ -20,6 +20,7 @@ spades.write_entities = t
 spades.seed = 10
 spades.entities_per_lp = 16
 spades.messages_per_lp = 16
+spades.messages_per_step = 1000
 spades.sort_type = "encoded"
 
 amrex.fpe_trap_invalid = 1


### PR DESCRIPTION
## Summary

Fix multiple entities per LP LVT. Basically when resetting the LVT on rollback we use the timestamp of the entity being rolled back. But it should really be set to the LVT of the maximum timestamp of the entities in the LP.